### PR TITLE
Fix multiply logging crash messages

### DIFF
--- a/lib/src/_app_runner.dart
+++ b/lib/src/_app_runner.dart
@@ -74,10 +74,8 @@ class _App extends StatelessWidget {
   }
 
   void _flutterErrorSetup() {
-    final FlutterExceptionHandler? oldCallback = FlutterError.onError;
-
     FlutterError.onError = (FlutterErrorDetails errorDetails) {
-      oldCallback?.call(errorDetails);
+      FlutterError.presentError(errorDetails);
       widgetConfig.onFlutterError(errorDetails);
     };
   }


### PR DESCRIPTION
Фикс единого запуска перезаписи функции отрабатывания ошибки.
Воспроизводилось просто при клике на экран краша, так же при хот-релоуде